### PR TITLE
Fix for issue 57: links array in response is empty

### DIFF
--- a/src/YouTubeDownloader.php
+++ b/src/YouTubeDownloader.php
@@ -135,7 +135,10 @@ class YouTubeDownloader
             $return = array();
 
             foreach ($formats_combined as $item) {
-                $cipher = isset($item['cipher']) ? $item['cipher'] : '';
+            	$cipher = '';
+                if(isset($item['cipher']) || isset($item['signatureCipher'])) {
+					$cipher = isset($item['cipher']) ? $item['cipher'] : $item['signatureCipher'];
+				}
                 $itag = $item['itag'];
 
                 // some videos do not need to be decrypted!


### PR DESCRIPTION
Fix for issue https://github.com/Athlon1600/youtube-downloader/issues/57 :
cipher was renamed to signatureCipher by YT so allow both