### PR TITLE
Fix getFirstCombinedFormat()->url returns only audio

### DIFF
--- a/src/DownloadOptions.php
+++ b/src/DownloadOptions.php
@@ -59,7 +59,7 @@ class DownloadOptions
     {
         return Utils::arrayFilterReset($this->getAllFormats(), function ($format) {
             /** @var $format StreamFormat */
-            return strpos($format->mimeType, 'video') === 0 && !empty($format->audioQuality);
+            return strpos($format->mimeType, 'video') === 0 && !empty($format->audioQuality) && $format->quality === 'hd720';
         });
     }
 


### PR DESCRIPTION
Fixes https://github.com/Athlon1600/youtube-downloader/issues/145
Thanks to @danpalmieri for the solution (https://github.com/Athlon1600/youtube-downloader/issues/145#issuecomment-960799498).